### PR TITLE
Ignore non-component selection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
   #       - windows-latest
   #       - macos-latest
   #       python:
-  #       - 3.8
   #       - 3.9
   #       - '3.10'
   #       - 3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "maya-zen-tools"
-version = "0.1.70"
+version = "0.1.71"
 description = "Zen Tools for Maya"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This change causes selection items which are not polygon components to simply be ignored rather than causing ZenTools to throw an error